### PR TITLE
docs(twitterAPI): add newline typo fix

### DIFF
--- a/ApiDesign/README.md
+++ b/ApiDesign/README.md
@@ -8,6 +8,9 @@ After installation, you can check on the terminal:
 
 `
 npm -v
+`
+
+`
 node -v
 `
 
@@ -15,6 +18,9 @@ If these two commands run properly, you can continue with:
 
 `
 cd ApiDesign
+`
+
+`
 npm install
 `
 


### PR DESCRIPTION
Just put an newline between two commands to indicate they are seperate commands in twitter API readme.md