### PR TITLE
Sidemenu & Routing

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,30 +1,3 @@
-
-
 <ion-app>
-
-  <ion-header>
-    <ion-toolbar>
-      <ion-menu-button color="tertiary" slot="primary">
-
-      </ion-menu-button>
-      <ion-title>
-        Actopus
-      </ion-title>
-
-    </ion-toolbar>
-  </ion-header>
-  <ion-menu>
-    <ion-item [href]="'/event'" >
-      Event
-    </ion-item>
-    <ion-item [href]="'/profile'" >
-      Profile
-    </ion-item>
-    <ion-item [href]="'/home'" >
-      Feed
-    </ion-item>
-  </ion-menu>
-  <ion-content main padding>
-    <ion-router-outlet></ion-router-outlet>
-  </ion-content>
+  <ion-router-outlet></ion-router-outlet>
 </ion-app>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -7,6 +7,10 @@ import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
 
 import { AppComponent } from './app.component';
+
+import { AuthModule } from './auth/auth.module';
+import { DataModule } from './data/data.module';
+
 import { AppConfigModule } from './app-config.module';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -16,6 +20,8 @@ import { AppRoutingModule } from './app-routing.module';
   imports: [
     BrowserModule,
     IonicModule.forRoot(),
+    AuthModule.forRoot(),
+    DataModule.forRoot(),
     AppConfigModule,
     AppRoutingModule
   ],

--- a/frontend/src/app/auth/auth.module.ts
+++ b/frontend/src/app/auth/auth.module.ts
@@ -5,7 +5,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
 import { AuthRoutingModule } from './auth-routing.module';
-import { JwtModule } from '@auth0/angular-jwt';
+import { JwtModule, JwtInterceptor, JwtHelperService, JWT_OPTIONS } from '@auth0/angular-jwt';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { SigninPage } from './pages/signin/signin.page';
 import { SignupPage } from './pages/signup/signup.page'
@@ -19,27 +20,43 @@ import { environment } from '../../environments/environment';
     HttpClientModule,
     IonicModule,
     ReactiveFormsModule,
-    AuthRoutingModule,
-    JwtModule.forRoot({
-      config: {
-        tokenGetter: tokenGetter,
-        whitelistedDomains: [ environment.endpoint ]
-      }
-    }),
+    AuthRoutingModule
   ],
   declarations: [
     SigninPage,
     SignupPage
   ],
   providers: [
-    AuthService
+    AuthService,
+    // JWT Providers
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: JwtInterceptor,
+      multi: true
+    },
+    {
+      provide: JWT_OPTIONS,
+      useValue: {
+        tokenGetter: tokenGetter,
+        whitelistedDomains: [ environment.endpoint ]
+      }
+    },
+    JwtHelperService
   ]
 })
 export class AuthModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: AuthModule,
-      providers: [ AuthService ]
+      providers: [
+        AuthService,
+        // JWT Interceptor
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: JwtInterceptor,
+          multi: true
+        }
+      ]
     }
   }
 }

--- a/frontend/src/app/auth/providers/auth/auth.service.ts
+++ b/frontend/src/app/auth/providers/auth/auth.service.ts
@@ -47,7 +47,7 @@ export class AuthService {
       .post('https://' + this.endpoint + '/api/auth/login', data, AuthService.options)
       .subscribe(response => {
         localStorage.setItem('token', response['token']);
-        this.router.navigate(['/home']);
+        this.router.navigate(['/feed']);
       });
   }
 

--- a/frontend/src/app/events/event-routing.module.ts
+++ b/frontend/src/app/events/event-routing.module.ts
@@ -6,7 +6,8 @@ import { FeedPage } from './pages/feed/feed.page';
 
 const routes: Routes = [
   { path: '', component: FeedPage },
-  { path: '/:id', component: EventPage },
+  { path: 'create', component: EventPage },
+  { path: ':id', component: EventPage }
 ];
 
 @NgModule({

--- a/frontend/src/app/events/events.module.ts
+++ b/frontend/src/app/events/events.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
-import { DataModule } from '../data/data.module';
 import { EventRoutingModule } from './event-routing.module';
 
 import { EventPage } from './pages/event/event.page';
@@ -16,8 +15,7 @@ import { EventCardComponent } from './components/event-card/event-card.component
     CommonModule,
     IonicModule,
     ReactiveFormsModule,
-    DataModule,
-    EventRoutingModule,
+    EventRoutingModule
   ],
   declarations: [
     EventPage,

--- a/frontend/src/app/events/pages/event/event.page.html
+++ b/frontend/src/app/events/pages/event/event.page.html
@@ -1,6 +1,11 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>event</ion-title>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/feed"></ion-back-button>
+    </ion-buttons>
+    <ion-title>
+      Event
+    </ion-title>
   </ion-toolbar>
 </ion-header>
 

--- a/frontend/src/app/events/pages/feed/feed.page.html
+++ b/frontend/src/app/events/pages/feed/feed.page.html
@@ -1,4 +1,21 @@
-<ion-content>
+<ion-header>
+  <ion-toolbar>
+    <ion-menu-button color="tertiary" slot="primary"></ion-menu-button>
+    <ion-title>
+      Actopus
+    </ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-menu>
+  <ion-item [href]="'/feed'" >
+    Feed
+  </ion-item>
+  <ion-item color="danger" (click)="logout()">
+    Sign out
+  </ion-item>
+</ion-menu>
+
+<ion-content main padding>
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
     <ion-fab-button [href]="'/feed/create'">
       <ion-icon name="add"></ion-icon>

--- a/frontend/src/app/events/pages/feed/feed.page.html
+++ b/frontend/src/app/events/pages/feed/feed.page.html
@@ -1,3 +1,10 @@
-<ion-list>
-  <app-event-card *ngFor="let event of events" [event]="event"></app-event-card>
-</ion-list>
+<ion-content>
+  <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+    <ion-fab-button [href]="'/feed/create'">
+      <ion-icon name="add"></ion-icon>
+    </ion-fab-button>
+  </ion-fab>
+  <ion-list>
+    <app-event-card *ngFor="let event of events" [event]="event" [routerLink]="'/feed/' + event._id"></app-event-card>
+  </ion-list>
+</ion-content>

--- a/frontend/src/app/events/pages/feed/feed.page.ts
+++ b/frontend/src/app/events/pages/feed/feed.page.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 
 import { Event } from '../../../interfaces';
+
+import { AuthService } from '../../../auth/providers/auth/auth.service';
 import { EventService } from '../../../data/providers/event/event.service';
 
 @Component({
@@ -11,7 +13,7 @@ import { EventService } from '../../../data/providers/event/event.service';
 export class FeedPage implements OnInit {
   private events: Event[];
 
-  constructor(private eventService: EventService) { }
+  constructor(private authService: AuthService, private eventService: EventService) { }
 
   ngOnInit() {
     this.eventService.get()
@@ -22,4 +24,7 @@ export class FeedPage implements OnInit {
       });
   }
 
+  logout() {
+    this.authService.logout();
+  }
 }


### PR DESCRIPTION
This PR builds on top of #205. Routing to the event details and event creation pages is set up. Sidemenu is build for the feed page and removed from the signin, signup pages. Some problems related with routing and modularization are resolved.