### PR TITLE
Update deploy.sh to include killall

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,4 +3,4 @@ HOST="root@46.101.223.116"
 
 # TODO: do scp with tar for efficiency
 scp -r backend $HOST:~
-ssh $HOST 'screen -XS "actopus:prod" quit; screen -dmS "actopus:prod" bash -c "cd ~/backend && npm install && sudo npm start"; exit'
+ssh $HOST 'screen -XS "actopus:prod" quit; screen -dmS "actopus:prod" bash -c "killall node && cd ~/backend && npm install && sudo npm start"; exit'


### PR DESCRIPTION
I checked CircleCI and saw that the server didn't start because the previous running server occupies port 3000. Since we use nodemon, this shouldn't cause us problems with the deployment but CircleCI thinks the deployment failed. This is because we either chose not to add or forgot to add the "killall node" command to our deploy.sh script.

@okyksl What is the behaviour we expect from CircleCI? I added the command to the deploy.sh file in this branch, do you think this should be merged?